### PR TITLE
mage-preview-2: errata / spelling fixes

### DIFF
--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -241,14 +241,14 @@ What then drew you forth to adventure? Did you learn of a secret trove of spells
 | 7th | +3 | 7|| —                                                      |4||4||3||3||1||—||—||—||—||—|
 | 8th | +3 | 8|| Ability Score Improvement                              |4||4||3||3||2||—||—||—||—||—|
 | 9th | +4 | 9|| —                                                      |4||4||3||3||3||1||—||—||—||—|
-| 10th| +4 |10|| Magical Study feature, Meta Magic                      |4||4||3||3||3||2||—||—||—||—|
+| 10th| +4 |10|| Magical Study feature, Metamagic                      |4||4||3||3||3||2||—||—||—||—|
 | 11th| +4 |11|| —                                                      |5||4||3||3||3||2||1||—||—||—|
 | 12th| +4 |12|| Ability Score Improvement                              |5||4||3||3||3||2||1||—||—||—|
 | 13th| +5 |13|| —                                                      |5||4||3||3||3||2||1||1||—||—|
 | 14th| +5 |14|| Magical Study feature                                  |5||4||3||3||3||2||1||1||—||—|
 | 15th| +5 |15|| —                                                      |5||4||3||3||3||2||1||1||1||—|
 | 16th| +5 |16|| Ability Score Improvement                              |5||4||3||3||3||2||1||1||1||—|
-| 17th| +6 |17|| Meta Magic                                             |5||4||3||3||3||2||1||1||1||1|
+| 17th| +6 |17|| Metamagic                                             |5||4||3||3||3||2||1||1||1||1|
 | 18th| +6 |18|| Spell Mastery                                          |5||4||3||3||3||3||1||1||1||1|
 | 19th| +6 |19|| Ability Score Improvement                              |5||4||3||3||3||3||2||1||1||1|
 | 20th| +6 |20|| Signature Spell                                        |5||4||3||3||3||3||2||2||1||1|
@@ -1256,7 +1256,7 @@ These are the changes made to the class since the last update released for the c
 ## General
 - Initial page has been rewritten a bit, "Creating a Mage" has been moved up there.
 - Quick creation pointers have been fleshed out.
-- Added full functionality of Sorcery Points and Meta Magic.
+- Added full functionality of Sorcery Points and Metamagic.
 - Removed Arcane Recovery, due to the change above.
 - Additional ribbon feature for first level.
 - 18th and 20th level unchanged (Spell Mastery, Signature Spell)

--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -535,7 +535,7 @@ You can change your list of prepared mage spells when you finish a short or a lo
 ___
 <div style='margin-top:-6px'></div>
 
-You can exert your control over magic to warp time itself. When a creature you can see within 60 feet of you begins their turn, you can use your reaction to allow that creature to take another action during that turn. When you do so, you gain one level of exhaustion.
+You can exert your control over magic to warp time itself. When a creature you can see within 60 feet of you begins their turn, you can use your reaction to allow that creature to take one additional action during its turn. When you do so, you gain one level of exhaustion.
 
 
 <img src='https://www.gmbinder.com/images/08NuEJc.png' style='position:absolute; right:0; bottom:0px; width:556px;' />

--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -638,7 +638,7 @@ At the end of a long rest, you can conjure a new water elemental. If you already
 
 Whenever a creature would take cold damage from one of your mage spells, its movement speed is reduced by 10 feet until the end of your next turn.
 
-When a creature has its speed reduced in this way, you can spend one sorcery point: that creature must succeed on a Strength saving throw against your spell save DC or be restrained for 1 minute. If a creature makes a successful hit against the creature the conditions caused by Brain Freeze are removed.
+When a creature has its speed reduced in this way, you can spend one sorcery point: that creature must succeed on a Strength saving throw against your spell save DC or be restrained for 1 minute. If a creature lands a successful hit against the creature the conditions caused by Brain Freeze are removed.
 
 Beginning at 14th level the creature becomes paralyzed instead of restrained.
 

--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -381,7 +381,7 @@ Others spot the message's presence with a successful DC 15 Wisdom (Perception) c
 You tap into a deep wellspring of magic within yourself. This wellspring is represented by sorcery points, which allow you to create a variety of magical effects.
 
 #### Sorcery Points
-You have 2 sorcery points, and you gain more as you reach higher levels, as shown in the Sorcery Points column of the Sorcerer table. You can never have more sorcery points than shown on the Mage table for your level. You regain all spent sorcery points when you finish a long rest.
+You have 2 sorcery points, and you gain more as you reach higher levels, as shown in the Sorcery Points column of the Mage table. You can never have more sorcery points than shown on the Mage table for your level. You regain all spent sorcery points when you finish a long rest.
 
 #### Flexible Casting
 You can use your sorcery points to gain additional spell slots, or sacrifice spell slots to gain additional sorcery points. You learn other ways to use your sorcery points as you reach higher levels.
@@ -484,7 +484,7 @@ Mages of the arcane are diviners of secrets, balancing the ebb and flow of incre
 *2nd-level Study of Arcane feature* 
 <div style='margin-top:-4px'></div>
 
-When you choose this magical study at 2nd level, you learn the *prestidigitation* cantrip. If you already know this cantrip, you learn a different wizard cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
+When you choose this magical study at 2nd level, you learn the *prestidigitation* cantrip. If you already know this cantrip, you learn a different mage cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
 
 #### Arcane Charges
 *2nd-level Study of Arcane feature* 
@@ -547,7 +547,7 @@ While any worthy mage is an unparalleled expert in the use of magic and heavily 
 *2nd-level Study of Fire feature* 
 <div style='margin-top:-4px'></div>
 
-When you choose this magical study at 2nd level, you learn the *control flames* cantrip. If you already know this cantrip, you learn a different wizard cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
+When you choose this magical study at 2nd level, you learn the *control flames* cantrip. If you already know this cantrip, you learn a different mage cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
 
 #### Hot Streak
 *2nd-level Study of Fire feature* 
@@ -597,7 +597,7 @@ Frost mages stand apart from their colleagues, in that their chosen school of ma
 *2nd-level Study of Frost feature* 
 <div style='margin-top:-4px'></div>
 
-When you choose this magical study at 2nd level, you learn the *shape water* cantrip. If you already know this cantrip, you learn a different wizard cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
+When you choose this magical study at 2nd level, you learn the *shape water* cantrip. If you already know this cantrip, you learn a different mage cantrip of your choice. The cantrip doesn't count against your number of cantrips known.
 
 #### Fingers of Frost
 *2nd-level Study of Frost feature* 
@@ -974,7 +974,7 @@ Blade of Disaster ^TCE^
 \pagebreakNum
 
 > ##### Extended spell list 
-> This list holds spells that are not in line with the Warcraft fantasy for mages, but a Dungeon Master could still allow a mage to learn. Many of these spells deal with necromancy or demonology, both of which are forbidden by most conclaves of magi. Others are powerful Wizard with no real equivalent in the Warcraft universe. 
+> This list holds spells that are not in line with the Warcraft fantasy for mages, but a Dungeon Master could still allow a mage to learn. Many of these spells deal with necromancy or demonology, both of which are forbidden by most conclaves of magi. Others are powerful Wizard spells with no real equivalent in the Warcraft universe. 
 > <br/> 
 > <br/> 
 >##### Cantrips (0 Level) 

--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -338,7 +338,7 @@ The Mage table shows how many spell slots you have to cast your spells of 1st le
 
 You prepare the list of mage spells that are available for you to cast. To do so, choose a number of mage spells from your spellbook equal to your Intelligence modifier + your mage level (minimum of one spell). The spells must be of a level for which you have spell slots.
 
-For example. if you're a 3rd-level mage, you have four <br/> 1st-level and two 2nd-level spell slots. With an Intelligence of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination, chosen from your spellbook. If you prepare the 1st-level spell magic missile, you can cast it using a 1st-level or a 2nd-level slot. Casting the spell doesn't remove it from your list of prepared.
+For example. if you're a 3rd-level mage, you have four <br/> 1st-level and two 2nd-level spell slots. With an Intelligence of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination, chosen from your spellbook. If you prepare the 1st-level spell *magic missile*, you can cast it using a 1st-level or a 2nd-level slot. Casting the spell doesn't remove it from your list of prepared.
 
 You can change your list of prepared spells when you finish a long rest. Preparing a new list of mage spells requires time spent studying your spellbook and memori-zing the incantations and gestures you must make to cast the spell: 1 minute per spell level for each spell on your list.
 
@@ -372,6 +372,7 @@ Your studies taught you how to sense residual magical energy. You can sense when
 \pagebreakNum
 
 Additionally you can create hidden magical writing in any language you know.
+
 Others spot the message's presence with a successful DC 15 Wisdom (Perception) check but can't decipher it without magic.
 
 ### Font of Magic
@@ -413,6 +414,7 @@ At 3rd level, you gain the ability to twist your spells to suit your needs. You 
 
 #### Careful Spell
 When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Intelligence modifier (minimum of one creature). 
+
 A chosen creature automatically succeeds on its saving throw against the spell.
 
 #### Distant Spell
@@ -420,11 +422,9 @@ When you cast a spell that has a range of 5 feet or greater, you can spend 1 sor
 
 When you cast a spell that has a range of touch, you can spend 1 sorcery point to have the spell's range be 30 feet.
 
-#### Transmuted Spell
-When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder. 
-
 #### Empowered Spell
 When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Intelligence modifier (minimum of 1). You must then use the new damage rolls.
+
 You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.
 
 #### Extended Spell
@@ -442,8 +442,12 @@ When you make an attack roll for a spell and miss, you can spend 2 sorcery point
 #### Subtle Spell
 When you cast a spell, you can spend 1 sorcery point to cast it without any somatic or verbal components.
 
+#### Transmuted Spell
+When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder. 
+
 #### Twinned Spell
 When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).
+
 To be eligible, a spell must be incapable of targeting more than one creature at the spell's current level. For example, magic missile and scorching ray aren't eligible, but ray of frost and chromatic orb are.
 
 ### Ability Score Improvement
@@ -573,7 +577,7 @@ Once you use this feature, you can’t use it again until you finish a long rest
 
 When you deal fire damage with a spell using a spell slot, up to 5th level, you can spend up to 3 sorcery points to empower it. For each sorcery point spent, add an extra die to  the damage dealt by the spell.
 
-For example, when you cast Burning Hands and spend 2 points, you add an extra 2d6 to the spell's damage. When you cast a spell that makes multiple attack rolls, such as Scorching Ray, you must spend the points on each attack individually.
+For example, when you cast *burning hands* and spend 2 points, you add an extra 2d6 to the spell's damage. When you cast a spell that makes multiple attack rolls, such as *scorching ray*, you must spend the points on each attack individually.
 
 #### Combustion
 *14th-level Study of Fire feature*
@@ -634,8 +638,7 @@ At the end of a long rest, you can conjure a new water elemental. If you already
 
 Whenever a creature would take cold damage from one of your mage spells, its movement speed is reduced by 10 feet until the end of your next turn.
 
-When a creature has its speed reduced in this way, you can spend one sorcery point: that creature must succeed on a Strength saving throw against your spell save DC or be restrained for 1 minute.
-If a creature makes a successful hit against the creature the conditions caused by Brain Freeze are removed.
+When a creature has its speed reduced in this way, you can spend one sorcery point: that creature must succeed on a Strength saving throw against your spell save DC or be restrained for 1 minute. If a creature makes a successful hit against the creature the conditions caused by Brain Freeze are removed.
 
 Beginning at 14th level the creature becomes paralyzed instead of restrained.
 
@@ -662,6 +665,7 @@ In addition, you can now spend sorcery points to cause the effect of Brain Freez
 <div style='margin-top:-4px'></div>
 
 You can use your action to conjure up a ring of magical runes to invoke the deepest cold around a point you can choose within 60 feet. The ring has a 30-foot-radius and fills a 10-foot tall cylinder with frigid cold. 
+
 Creatures inside the area must succeed on a strength saving throw against your spell save DC or become paralyzed for up to 1 minute or until they take damage. If a creature’s body is fully inside the area the save is made with disadvantage. On a successful save a creature isn't restrained.
 
 Additionally creatures passing through the area with non-magical means have their movement speed halved until the end of their next turn after leaving the area. Additionally ranged attacks made through the area are made with disadvantage.
@@ -758,7 +762,7 @@ Alarm
 <br/> Expeditious Retreat
 <br/> Feather Fall
 <br/> Find Familiar
-<br/> Frost Fingers ^ID:RotF^
+<br/> Frost Fingers ^IDRotF^
 <br/> ✦ Frostfire Bolt
 <br/> Gift of Alacrity ^EGW^
 <br/> Hellish Rebuke
@@ -1015,7 +1019,7 @@ Blade of Disaster ^TCE^
 > <br/> Forbiddance
 > <br/> <br/>
 >##### 7th Level
-> Create Magen ^ID:RotF^
+> Create Magen ^IDRotF^
 > <br/> Finger of Death
 > <br/> Plane Shift
 > <br/> <br/>


### PR DESCRIPTION
This branch is open for hotfixing various typos and minor errata popping up the first days following mage-preview-2 being released.

Also just to mark off issues that should be closed with preview-2, since they're still open: 

fixes #605, fixes #683 

Then there is 711, which is in the Death Knight patch Tyloris has up, so it would stay open until that is also resolved. 👍 

Review doc link (last updated for 0fb2d35): 
https://www.gmbinder.com/share/-MRF_5mQ_WVvTVaM1zla