### PR TITLE
Adjust wording of Rogue's Trick of the Trade feature (#748)

### DIFF
--- a/WIP 3.0 Classes/Rogue
+++ b/WIP 3.0 Classes/Rogue
@@ -411,7 +411,7 @@ At 9th level, immediately after you take the Attack action on your turn, you can
 You must be wielding a pistol or have an empty hand that can draw one (no action required) to use this energy move.
 
 #### Tricks of the Trade
-Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while within 5 feet of a creature, you can use your reaction to have the attack target that creature instead of you.
+Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while within 5 feet of a creature other than the attacker, you can use your reaction to have the attack target that creature instead of you.
 
 You can use this feature twice. You regain all spent uses when you finish a short or long rest.
 


### PR DESCRIPTION
Disallow redirecting the attack back to the attacker. Closes #748.