### PR TITLE
Reorganize languages for better consistency with modern lore

### DIFF
--- a/WIP 3.0 Chapters/Chapter 1 Races
+++ b/WIP 3.0 Chapters/Chapter 1 Races
@@ -528,27 +528,28 @@ Dozens of languages can be heard across Azeroth, and every tongue has dialects a
 |:------------------|:------------|:-----------|
 |&nbsp; Common      | Humans      | Common     |
 |&nbsp; Darnassian  | Night Elves | Darnassian |
-|&nbsp; Draenei     | Draenei     | Eredic     |
+|&nbsp; Draenei     | Draenei     | Eredun     |
 |&nbsp; Dwarven     | Dwarves     | Dwarvish   |
 |&nbsp; Goblin      | Goblins     | Common     |
 |&nbsp; Gnomish     | Gnomes      | Common     |
 |&nbsp; Gutterspeak | Forsaken    | —          |
-|&nbsp; Mogu        | Pandaren    | Mogu       |
-|&nbsp; Orcish      | Orcs        | Common     |
+|&nbsp; Orcish      | Orcs        | Orcish     |
+|&nbsp; Pandaren    | Pandaren    | Mogu       |
 |&nbsp; Shalassian  | Nightborne  | Darnassian |
-|&nbsp; Taur-ahe    | Taurens     | Taur-ahe   |
+|&nbsp; Taur-ahe    | Tauren      | Taur-ahe   |
 |&nbsp; Thalassian  | High Elves  | Darnassian |
 |&nbsp; Zandali     | Trolls      | Zandali    |
 
 ##### Exotic Languages
 |&nbsp; Language    | Typical Speakers | Script        |
 |:------------------|:-----------------|:--------------|
-|&nbsp; Celestial   | Celestials       | Celestial     |
 |&nbsp; Draconic    | Dragons          | Draconic      |
-|&nbsp; Eredun      | Demons           | Eredic        |
-|&nbsp; Giant       | Ogres            | —             |
+|&nbsp; Eredun      | Demons           | Eredun        |
 |&nbsp; Kalimag     | Elementals       | Kalimag       |
-|&nbsp; Low Common  | Lesser Races     | Common        |
+|&nbsp; Low Common  | Monstrous Races  | Common        |
+|&nbsp; Ogre        | Ogres            | Ogre          |
+|&nbsp; Shath'Yar   | Old Gods         | Shath'Yar     |
+|&nbsp; Titan       | Titan-forged     | Titan         |
 
 <img src='https://www.gmbinder.com/images/1Hhc7zP.jpg' style='position:absolute; top:700px; right:-80px; width:500px' />
 <img src='https://www.gmbinder.com/images/huxbNse.png' style='position:absolute; top:200px; right:0px; width:900px; transform:scaley(-1)' />
@@ -2154,7 +2155,7 @@ Your pandaren character has the following racial traits.
 
 After you use your quaking palm, you can't use it again until you finish a short or long rest.
 
-***Languages.*** You can speak, read, and write, Common and Mogu. Mogu is the language of Pandaria, forced upon the inhabitants of Pandaria by the mogu empire. It is a strange and unfamiliar language to the rest of Azeroth, with a multitude of words meaning one common thing.
+***Languages.*** You can speak, read, and write Common and Pandaren. Pandaren is the language of Pandaria, a descendant of the Mogu language forced upon the inhabitants of Pandaria by the mogu empire. It is a strange and unfamiliar language to the rest of Azeroth, with a multitude of words meaning one common thing.
 
 <img src='https://www.gmbinder.com/images/SvYw20C.jpg' style='position:absolute; top:700px; right:0px; width:800px' />
 <img src='https://www.gmbinder.com/images/L60ii4e.png' style='position:absolute; top:0px; right:0px; width:850px; transform:scalex(-1)' />


### PR DESCRIPTION
Hello everyone,

I've updated the languages table for better consistency with official modern lore. You're free to use only parts of this edit or not use it at all.

Justifications for the changes:

Standard Languages:
* Orcish has its own runic writing system instead of using the Common one (source: TFT Maiev mission 2).
* There is no evidence that "Eredic" is a word (zero mentions on Wowpedia). "Eredun", however, is well established, and can work as both the language name and the script name, IMHO.
* Modern Pandaren is not the same language as the Mogu language spoken before the Sundering (source: the quest "[It Was Almost Alive](https://wowpedia.fandom.com/wiki/It_Was_Almost_Alive)", Lorewalker Cho has difficulty translating ancient mogu writing, and [Lorewalker Amai](https://wowpedia.fandom.com/wiki/Lorewalker_Amai#History_lesson) mentions that hardly anyone speaks the old tongue of emperors and scholars anymore). It is, however, undoubtably a descendant of it, as the mogu forced their own language on Pandaria, forcing the pandaren to forget whatever language they had before that. The language spoken by pandaren is also called "Pandaren" in-game.
* The plural of "tauren" is "tauren", not "taurens".

Exotic Languages:
* There is no evidence for a Celestial language existing in the Warcraft setting.
* The Giant language was only mentioned in the non-canon RPG, which considered ogres a type of giants (as an artifact of its D&D roots). [The ogre language](https://wowpedia.fandom.com/wiki/Ogre_(language)) has its own form of writing, which we might as well call "Ogre" for lack of an official name.
* Titan and Shath'Yar are of great importance to historians and archaeologists of Azeroth, yet they were missing from the list.
* This is debatable, but the wording "Lesser Races" has unfortunate real-life implications in my eyes. "Monstrous Races", on the other hand, would be consistent in wording with the Monstrous Races document.

Pandaren:
* Renamed the Mogu language to Pandaren, per above, and mentioned that it's a descendant of Mogu.