### PR TITLE
Fix mindfart for Doomskull balance.

### DIFF
--- a/WIP Manual of Monsters/Scourge.md
+++ b/WIP Manual of Monsters/Scourge.md
@@ -507,11 +507,11 @@ https://wowpedia.fandom.com/wiki/Flesh_giant
 \pagebreak
 
 ___
-> ## Doomskull <!-- https://wc5e-cr-calculator.frogvall.com/?0;15;49;5;13;35;0;28;13;28;13;0;0;0;0;0;0;;;;;3;;;;;;;;;;1;1;;;;;;;10;;;;;;;3;2;2;5;Shadow%20Bolt;Magic%20Missile;Phantasmal%20Force -->
+> ## Doomskull <!-- https://wc5e-cr-calculator.frogvall.com/?0;15;54;5;13;16;0;28;13;28;13;0;0;0;0;0;0;;;;;3;;;;;;;;;;1;1;;;;;;;10;;;;;;;3;2;2;5;Shadow%20Bolt;Magic%20Missile;Phantasmal%20Force -->
 > *Tiny undead, chaotic evil*
 > ___
 > - **Armor Class** 15
-> - **Hit Points** 49 (11d4 + 22)
+> - **Hit Points** 54 (12d4 + 24)
 > - **Speed** 0 ft., fly 40 ft. (hover)
 > ___
 > STR | DEX | CON | INT | WIS | CHA


### PR DESCRIPTION
When recalculating the Doomskull CR with the new table, and calculator, I somehow assumed you could cast two level 1 spells (hex and magic missile) in the same turn. You can't (but you can cast Hex + Shadow Bolt). I hence lowered the HP to compensate, but that was wrong.

This I discovered when using them in play, so I fixed it and I hereby push back to the project to clean up my own mess.