### PR TITLE
Life Tap patch

### DIFF
--- a/WIP 3.0 Classes/Warlock.md
+++ b/WIP 3.0 Classes/Warlock.md
@@ -391,9 +391,7 @@ You can use an arcane focus as a spellcasting focus for your warlock spells.
 
 <div style='margin-top:-4px'></div>
 
-When you do not have any Fel Sorcery spell slots remain&shy;ing, you can still cast a spell as though you do. As part of the action to cast the spell, your current and maximum hit points are reduced by an amount equal to three times your Fel Sorcery slot level.
-
-This damage cannot be resisted or ignored, and you cannot use this feature if doing so would reduce you to 0 hit points. Your maximum hit point total is restored when you finish a long rest.
+You can choose to cast a spell without expending a slot by instead sacrificing your hit points. When you cast a spell, your current hit points and hit point maximum is reduced by an amount equal to three times the spell’s level. You choose the spell level, up to your Fel Sorcery slot level. You cannot use this feature if it would reduce your hit points <br/> to 0. This reduction lasts until you finish a long rest.
 
 ### Fel Study
 *2nd-level warlock feature*


### PR DESCRIPTION
Changes Life Tap to:
- Be able to be used whenever, not just when you are out of spell slots
- Allow you to determine what level the spell is when you cast it, instead of tying it to Fel Sorcery slots (so that you aren't burning enough hit points to power a 5th level version of a non-scaling spell like Alarm)
- Open it up to non-warlock spells, instead being any spell you know (for multiclass shenanigans and feat/racial spells)
- Also clarifies some language, removing reference to an older version of the ability (there is no damage to be resisted)