### PR TITLE
Fix typo: Locust-Walker -> Locus-Walker

### DIFF
--- a/WIP 3.0 Chapters/Chapter 1 Races
+++ b/WIP 3.0 Chapters/Chapter 1 Races
@@ -2182,9 +2182,9 @@ However, the other magisters did not agree. Least of all the Grand Magister, who
 Now, emboldened by their newfound powers, the void elves have sworn to make their claim on the world, under the joint leadership of magister Umbric and Alleria Windrunner. 
 
 ### Ethereals, Friend and Foe
-Beings of energy, Ethereals are extradimensional creatures that have travelled great distances across the Great Dark. Normally composed of arcane energies, it is a group of void-touched Ethereals that have turned the Ren'dorei into what they are today. Alleria Windrunner, co-leader to Magister Umbric, owed much of her power to the teachings of an Ethereal named Locust-Walker.
+Beings of energy, Ethereals are extradimensional creatures that have travelled great distances across the Great Dark. Normally composed of arcane energies, it is a group of void-touched Ethereals that have turned the Ren'dorei into what they are today. Alleria Windrunner, co-leader to Magister Umbric, owed much of her power to the teachings of an Ethereal named Locus-Walker.
 
-It was only thanks to the machinations of void ethereals hoping to turn Magister Umbric and his followers into true creatures of void along with the timely intervention of Alleria Windrunner that has turned these former denizens of Quel'thalas into something more. Now Locust-Walker along with other ethereals who's goals aligned with the Ren'dorei roam their base of Telogrus Rift, teaching and guiding all Children of Quel'thalas in the ways of the Void.
+It was only thanks to the machinations of void ethereals hoping to turn Magister Umbric and his followers into true creatures of void along with the timely intervention of Alleria Windrunner that has turned these former denizens of Quel'thalas into something more. Now Locus-Walker along with other ethereals who's goals aligned with the Ren'dorei roam their base of Telogrus Rift, teaching and guiding all Children of Quel'thalas in the ways of the Void.
 
 \columnbreak
 


### PR DESCRIPTION
The ethereal who taught Alleria void magic was called [Locus-Walker](https://wowpedia.fandom.com/wiki/Locus-Walker), not Locust-Walker. This PR fixes the name.