### PR TITLE
fix: add missing XGE label

### DIFF
--- a/WIP 3.0 Chapters/Chapter 6 Spells
+++ b/WIP 3.0 Chapters/Chapter 6 Spells
@@ -535,7 +535,7 @@ Foresight
 <br/> Prestidigitation
 <br/> Produce Flame
 <br/> Ray of Frost
-<br/> Shape Water
+<br/> Shape Water ^XGE^
 
 ##### 1st Level
 Alarm


### PR DESCRIPTION
Shape Water spell has the "XGE" label in two of the three places. Added missing one