### PR TITLE
Correct level in the Magical Study section description

### DIFF
--- a/WIP 3.0 Classes/Mage.md
+++ b/WIP 3.0 Classes/Mage.md
@@ -416,7 +416,7 @@ You can transform unexpended sorcery points into one spell slot as a bonus actio
 
 You choose a magical study, shaping your practice of magic through one of three areas: Arcane, Fire or Frost, all detailed at the end of the class description.
 
-Your choice grants you features at 3rd level and again at 6th, 10th, and 14th level.
+Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level.
 
 ### Metamagic
 *3rd-level mage feature* 


### PR DESCRIPTION
The description of the Mage's Magical Study section incorrectly states that the first feature is gained at 3rd level. This PR corrects it to 2nd level.